### PR TITLE
fix encoding option to bmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Options - object, that can contain:
 |noPreview|boolean|true|Disables preview window on Pi while taking photo|
 |outputDir|string|'./photos'|Output directory where photos will be stored|
 |fileName|string|undefined|Name for photo file. If undefined - photos file names will be calculated as new Date.now() + file encoding|
-|encoding|string|'jpg'|'jpg', 'bpm', 'gif' or 'png'|
+|encoding|string|'jpg'|'jpg', 'bmp', 'gif' or 'png'|
 |width|number|undefined|Width of taken image in pixels. If width is not set - raspistill uses default max camera sensor resolution width|
 |height|number|undefined|Height of taken image in pixels. If height is not set - raspistill uses default max camera sensor resolution height|
 |time|number|undefined|Time before camera takes photo. If undefined raspistill util use it's own 5 sec timeout|

--- a/src/lib/camera/interfaces.ts
+++ b/src/lib/camera/interfaces.ts
@@ -1,4 +1,4 @@
-export type TCameraFileEncoding = 'jpg' | 'bpm' | 'gif' | 'png';
+export type TCameraFileEncoding = 'jpg' | 'bmp' | 'gif' | 'png';
 
 export interface ICameraOptions {
     /**
@@ -20,7 +20,7 @@ export interface ICameraOptions {
      */
     fileName?: string;
     /**
-     * File encoding. jpg, bpm, gif or png
+     * File encoding. jpg, bmp, gif or png
      */
     encoding?: TCameraFileEncoding;
     width?: number;


### PR DESCRIPTION
I think `bmp` was meant instead of `bpm`?